### PR TITLE
Allow pipeline names to contain spaces

### DIFF
--- a/notebook/pipeline/_notebook_op.py
+++ b/notebook/pipeline/_notebook_op.py
@@ -91,13 +91,13 @@ class NotebookOp(ContainerOp):
                                    'python bootstrapper.py '
                                    ' --endpoint %s '
                                    ' --bucket %s '
-                                   ' --directory %s '
-                                   ' --tar-archive %s '
+                                   ' --directory "%s" '
+                                   ' --tar-archive "%s" '
                                    ' --pipeline-outputs %s '
                                    ' --pipeline-inputs %s '
-                                   ' --input %s '
-                                   ' --output %s '
-                                   ' --output-html %s' % (
+                                   ' --input "%s" '
+                                   ' --output "%s" '
+                                   ' --output-html "%s"' % (
                                        self.container_work_dir,
                                        self.container_work_dir,
                                        self.bootstrap_script_url,


### PR DESCRIPTION
This will allow kubeflow pipelines to have spaces in the name.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

