### PR TITLE
Update Jupyter Client in bootstrapper script

### DIFF
--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -21,6 +21,7 @@ def import_with_auto_install(package):
     try:
         return __import__(package)
     except ImportError:
+        print('Updating package {}'.format(package))
         subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--upgrade', package])
 
 
@@ -97,6 +98,7 @@ def put_file_object_store(client, bucket_name, file_to_upload, subdir):
 
 
 if __name__ == '__main__':
+    import_with_auto_install("jupyter_client")
     import_with_auto_install("papermill")
     import_with_auto_install("minio")
     import_with_auto_install("argparse")


### PR DESCRIPTION
This address incompatible versions that were causing
cannot import name 'AsyncKernelManager' from 'jupyter_client'

Fixes #18 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

