### PR TITLE
Handle pip packages installed from source

### DIFF
--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -26,7 +26,11 @@ def package_install():
 
     for package, ver in elyra_package_list.items():
         if package in current_package_list:
-            if version.parse(ver) > version.parse(current_package_list[package]):
+            if "git+" in current_package_list[package]:
+                print("WARNING: Source package %s found already installed from %s. This may "
+                      "conflict with the required version: %s . Skipping..." %
+                      (package, current_package_list[package], ver))
+            elif version.parse(ver) > version.parse(current_package_list[package]):
                 print("Updating %s package from version %s to %s..." % (package, current_package_list[package], ver))
                 to_install_list.append(package+'=='+ver)
             elif version.parse(ver) < version.parse(current_package_list[package]):
@@ -45,7 +49,11 @@ def package_list_to_dict(filename):
     with open(filename) as fh:
         for line in fh:
             if line[0] != '#':
-                package_name, package_version = line.strip('\n').split(sep="==")
+                if " @ " in line:
+                    package_name, package_version = line.strip('\n').split(sep=" @ ")
+                else:
+                    package_name, package_version = line.strip('\n').split(sep="==")
+
                 package_dict[package_name] = package_version
 
     return package_dict

--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -51,6 +51,8 @@ def package_list_to_dict(filename):
             if line[0] != '#':
                 if " @ " in line:
                     package_name, package_version = line.strip('\n').split(sep=" @ ")
+                elif "===" in line:
+                    package_name, package_version = line.strip('\n').split(sep="===")
                 else:
                     package_name, package_version = line.strip('\n').split(sep="==")
 


### PR DESCRIPTION
This resolves an issue where python packages installed
from source were not being parsed correctly when using
pip freeze. This also warns users if a dependency from
Elyra is in conflict with one installed from source.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

