### PR TITLE
Fix handling of input and output parameters

### DIFF
--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -112,13 +112,13 @@ class NotebookOp(ContainerOp):
                                  )
 
             if self.pipeline_inputs:
-                argument_list.append(['--inputs', self.pipeline_inputs])
+                argument_list.append('--inputs "{}" '.format(self.pipeline_inputs))
 
             if self.pipeline_outputs:
-                argument_list.append(['--outputs', self.pipeline_outputs])
+                argument_list.append('--outputs "{}" '.format(self.pipeline_outputs))
 
             kwargs['command'] = ['sh', '-c']
-            kwargs['arguments'] = argument_list
+            kwargs['arguments'] = "".join(argument_list)
 
         super().__init__(**kwargs)
 
@@ -138,10 +138,10 @@ class NotebookOp(ContainerOp):
         return name_with_extension
 
     def add_pipeline_inputs(self, pipeline_inputs):
-        self.container.args[0] += ("--inputs " + pipeline_inputs)
+        self.container.args[0] += ('--inputs "{}" '.format(pipeline_inputs))
 
     def add_pipeline_outputs(self, pipeline_outputs):
-        self.container.args[0] += ("--outputs " + pipeline_outputs)
+        self.container.args[0] += ('--outputs "{}" '.format(pipeline_outputs))
 
     def add_environment_variable(self, name, value):
         self.container.add_env_variable(V1EnvVar(name=name, value=value))


### PR DESCRIPTION
Fix multiples issues described in 'elyra-693'
where the runtime was failing when both input
and output parameters were provided.

Also, fix the possible errors by properly 
encapsulating the content of these parameters
with quotes.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

