### PR TITLE
Infer value of bool secure parameter from endpoint scheme

### DIFF
--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -172,7 +172,7 @@ def main():
     cos_client = minio.Minio(cos_endpoint.netloc,
                              access_key=os.getenv('AWS_ACCESS_KEY_ID'),
                              secret_key=os.getenv('AWS_SECRET_ACCESS_KEY'),
-                             secure=False)
+                             secure=cos_endpoint.scheme == 'https')
 
     get_file_from_object_storage(cos_client, input_params['cos-bucket'], input_params['cos-dependencies-archive'])
 


### PR DESCRIPTION
This change uses the scheme from the `cos_endpoint` to determine the value of the `secure` parameter.  Minio, performs the opposite operation by checking `secure` and adding the corresponding scheme to the endpoint.

This is a sibling PR to https://github.com/elyra-ai/elyra/pull/774.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

