### PR TITLE
Add support for ODH and use of CRI-o container runtime in OpenShift

### DIFF
--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -52,7 +52,7 @@ def package_install():
             to_install_list.append(package+'=='+ver)
 
     if to_install_list:
-        if 'user-volume-path' in input_params:
+        if input_params['user-volume-path']:
             to_install_list.insert(0, '--target=' + input_params['user-volume-path'])
         subprocess.check_call([sys.executable, '-m', 'pip', 'install'] + to_install_list)
 

--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -52,8 +52,8 @@ def package_install():
             to_install_list.append(package+'=='+ver)
 
     if to_install_list:
-        if 'crio-python-user-lib-path' in input_params:
-            to_install_list.insert(0, '--target=' + input_params['crio-python-user-lib-path'])
+        if 'user-volume-path' in input_params:
+            to_install_list.insert(0, '--target=' + input_params['user-volume-path'])
         subprocess.check_call([sys.executable, '-m', 'pip', 'install'] + to_install_list)
 
 
@@ -86,7 +86,7 @@ def parse_arguments(args):
     parser.add_argument('-n', '--notebook', dest="notebook", help='Notebook to execute', required=True)
     parser.add_argument('-o', '--outputs', dest="outputs", help='Files to output to object store', required=False)
     parser.add_argument('-i', '--inputs', dest="inputs", help='Files to pull in from parent node', required=False)
-    parser.add_argument('-r', '--crio-python-user-lib-path', dest="crio-python-user-lib-path", help='Directory in Volume to install python libraries into', required=False)
+    parser.add_argument('-r', '--user-volume-path', dest="user-volume-path", help='Directory in Volume to install python libraries into', required=False)
     parsed_args = vars(parser.parse_args(args))
 
     return parsed_args

--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -52,6 +52,8 @@ def package_install():
             to_install_list.append(package+'=='+ver)
 
     if to_install_list:
+        if 'crio-python-user-lib-path' in input_params:
+            to_install_list.insert(0, '--target=' + input_params['crio-python-user-lib-path'])
         subprocess.check_call([sys.executable, '-m', 'pip', 'install'] + to_install_list)
 
 
@@ -84,6 +86,7 @@ def parse_arguments(args):
     parser.add_argument('-n', '--notebook', dest="notebook", help='Notebook to execute', required=True)
     parser.add_argument('-o', '--outputs', dest="outputs", help='Files to output to object store', required=False)
     parser.add_argument('-i', '--inputs', dest="inputs", help='Files to pull in from parent node', required=False)
+    parser.add_argument('-r', '--crio-python-user-lib-path', dest="crio-python-user-lib-path", help='Directory in Volume to install python libraries into', required=False)
     parsed_args = vars(parser.parse_args(args))
 
     return parsed_args
@@ -181,6 +184,9 @@ def process_output_file(cos_client, bucket, output_file):
 
 
 def main():
+    global input_params
+    input_params = parse_arguments(sys.argv[1:])
+
     package_install()
     subprocess.check_call([sys.executable, '-m', 'pip', 'freeze'])
 
@@ -190,9 +196,6 @@ def main():
     from urllib.parse import urlparse
 
     print("Package Installation Complete.....")
-
-    global input_params
-    input_params = parse_arguments(sys.argv[1:])
 
     cos_endpoint = urlparse(input_params['cos-endpoint'])
     cos_client = minio.Minio(cos_endpoint.netloc,

--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -86,7 +86,7 @@ def parse_arguments(args):
     parser.add_argument('-n', '--notebook', dest="notebook", help='Notebook to execute', required=True)
     parser.add_argument('-o', '--outputs', dest="outputs", help='Files to output to object store', required=False)
     parser.add_argument('-i', '--inputs', dest="inputs", help='Files to pull in from parent node', required=False)
-    parser.add_argument('-r', '--user-volume-path', dest="user-volume-path", help='Directory in Volume to install python libraries into', required=False)
+    parser.add_argument('-p', '--user-volume-path', dest="user-volume-path", help='Directory in Volume to install python libraries into', required=False)
     parsed_args = vars(parser.parse_args(args))
 
     return parsed_args

--- a/etc/tests/test_bootstrapper.py
+++ b/etc/tests/test_bootstrapper.py
@@ -381,7 +381,7 @@ def test_parse_arguments():
                  '-t', 'test-archive.tgz',
                  '-n', 'test-notebook.ipynb',
                  '-b', 'test-bucket',
-                 '-f', '/tmp/lib']
+                 '-p', '/tmp/lib']
     args_dict = bootstrapper.parse_arguments(test_args)
 
     assert args_dict['cos-endpoint'] == 'http://test.me.now'

--- a/etc/tests/test_bootstrapper.py
+++ b/etc/tests/test_bootstrapper.py
@@ -213,14 +213,14 @@ def test_package_installation(monkeypatch, virtualenv):
     correct_dict = {'ipykernel': '5.3.0',
                     'ansiwrap': '0.8.4',
                     'packaging': '20.4',
-                    'text-extensions-for-pandas':
-                    "git+https://github.com/akchinSTC/text-extensions-for-pandas@50d5a1688fb723b5dd8139761830d3419042fee5"
+                    'text-extensions-for-pandas': "0.0.1-prealpha"
                     }
 
     mocked_func = mock.Mock(return_value="default", side_effect=[elyra_dict, to_install_dict])
 
     monkeypatch.setattr(bootstrapper, "package_list_to_dict", mocked_func)
     monkeypatch.setattr(sys, "executable", virtualenv.python)
+    monkeypatch.setattr(bootstrapper, 'input_params', {'user-volume-path': None})
 
     virtualenv.run("python -m pip install bleach==3.1.5")
     virtualenv.run("python -m pip install ansiwrap==0.7.0")

--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -150,7 +150,7 @@ class NotebookOp(ContainerOp):
                 argument_list.append('--outputs "{}" '.format(outputs_str))
 
             if self.emptydir_volume_size:
-                argument_list.append(('--user-volume-path "{}" '.format(self.python_user_lib_path)))
+                argument_list.append('--user-volume-path "{}" '.format(self.python_user_lib_path))
 
             kwargs['command'] = ['sh', '-c']
             kwargs['arguments'] = "".join(argument_list)

--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -74,7 +74,9 @@ class NotebookOp(ContainerOp):
         self.cos_bucket = cos_bucket
         self.cos_directory = cos_directory
         self.cos_dependencies_archive = cos_dependencies_archive
-        self.container_work_dir = "jupyter-work-dir"
+        self.container_work_dir_root_path = "./"
+        self.container_work_dir_name = "jupyter-work-dir"
+        self.container_work_dir = self.container_work_dir_root_path + self.container_work_dir_name
         self.bootstrap_script_url = bootstrap_script_url
         self.requirements_url = requirements_url
         self.pipeline_outputs = pipeline_outputs
@@ -92,7 +94,8 @@ class NotebookOp(ContainerOp):
         self.python_user_lib_path_target = ''
 
         if self.emptydir_volume_size:
-            self.container_work_dir = "/mnt/" + self.container_work_dir
+            self.container_work_dir_root_path = "/mnt/"
+            self.container_work_dir = self.container_work_dir_root_path + self.container_work_dir_name
             self.python_user_lib_path = self.container_work_dir + '/python3.6/'
             self.python_user_lib_path_target = '--target=' + self.python_user_lib_path
 
@@ -123,7 +126,7 @@ class NotebookOp(ContainerOp):
                                  'curl -H "Cache-Control: no-cache" -L {reqs_url} --output requirements-elyra.txt && '
                                  'python -m pip install {python_user_lib_path_target} packaging && '
                                  'python -m pip freeze > requirements-current.txt && '
-                                 'python {container_work_dir}/bootstrapper.py '
+                                 'python bootstrapper.py '
                                  '--cos-endpoint {cos_endpoint} '
                                  '--cos-bucket {cos_bucket} '
                                  '--cos-directory "{cos_directory}" '

--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -19,8 +19,8 @@ import os
 
 from kfp.dsl._container_op import ContainerOp
 from kfp_notebook import __version__
-from kubernetes.client.models import V1EnvVar
 from typing import Dict, List, Optional
+from kubernetes.client.models import V1EnvVar, V1Volume, V1EmptyDirVolumeSource, V1VolumeMount
 
 """
 The NotebookOp uses a python script to bootstrap the user supplied image with the required dependencies.
@@ -49,6 +49,7 @@ class NotebookOp(ContainerOp):
                  pipeline_envs: Optional[Dict[str,str]] = None,
                  requirements_url: str = None,
                  bootstrap_script_url: str = None,
+                 crio_emptydir_volume_size: str = None,
                  **kwargs):
         """Create a new instance of ContainerOp.
         Args:
@@ -81,6 +82,22 @@ class NotebookOp(ContainerOp):
 
         argument_list = []
 
+        # CRI-o support for kfp pipelines
+        # We need to attach an emptydir volume for each notebook that runs since CRI-o runtime does not allow
+        # us to write to the base image layer file system, only to volumes.
+        self.crio_emptydir_volume_name = "workspace"
+        self.crio_emptydir_volume_size = crio_emptydir_volume_size
+        self.crio_python_user_lib_path = ''
+        self.crio_python_user_lib_path_target = ''
+
+        if self.crio_emptydir_volume_size:
+            self.container_work_dir = "/mnt/" + self.container_work_dir
+            self.crio_python_user_lib_path = self.container_work_dir + '/python3.6/'
+            self.crio_python_user_lib_path_target = '--target=' + self.crio_python_user_lib_path
+
+        KFP_NOTEBOOK_ORG = 'akchinstc'
+        KFP_NOTEBOOK_BRANCH = 'odh-support'
+
         if not self.bootstrap_script_url:
             self.bootstrap_script_url = 'https://raw.githubusercontent.com/{org}/' \
                                         'kfp-notebook/{branch}/etc/docker-scripts/bootstrapper.py'.\
@@ -103,12 +120,12 @@ class NotebookOp(ContainerOp):
                 NOTE: Images being pulled must have python3 available on PATH and cURL utility
             """
 
-            argument_list.append('mkdir -p ./{container_work_dir} && cd ./{container_work_dir} && '
+            argument_list.append('mkdir -p {container_work_dir} && cd {container_work_dir} && '
                                  'curl -H "Cache-Control: no-cache" -L {bootscript_url} --output bootstrapper.py && '
                                  'curl -H "Cache-Control: no-cache" -L {reqs_url} --output requirements-elyra.txt && '
-                                 'python -m pip install packaging && '
+                                 'python -m pip install {crio_python_user_lib_path_target} packaging && '
                                  'python -m pip freeze > requirements-current.txt && '
-                                 'python bootstrapper.py '
+                                 'python {container_work_dir}/bootstrapper.py '
                                  '--cos-endpoint {cos_endpoint} '
                                  '--cos-bucket {cos_bucket} '
                                  '--cos-directory "{cos_directory}" '
@@ -121,9 +138,11 @@ class NotebookOp(ContainerOp):
                                     cos_bucket=self.cos_bucket,
                                     cos_directory=self.cos_directory,
                                     cos_dependencies_archive=self.cos_dependencies_archive,
-                                    notebook=self.notebook
+                                    notebook=self.notebook,
+                                    crio_python_user_lib_path_target=self.crio_python_user_lib_path_target,
                                     )
                                  )
+
             if self.pipeline_inputs:
                 inputs_str = self._artifact_list_to_str(self.pipeline_inputs)
                 argument_list.append('--inputs "{}" '.format(inputs_str))
@@ -131,6 +150,9 @@ class NotebookOp(ContainerOp):
             if self.pipeline_outputs:
                 outputs_str = self._artifact_list_to_str(self.pipeline_outputs)
                 argument_list.append('--outputs "{}" '.format(outputs_str))
+
+            if self.crio_emptydir_volume_size:
+                argument_list.append(('--crio-python-user-lib-path "{}" '.format(self.crio_python_user_lib_path)))
 
             kwargs['command'] = ['sh', '-c']
             kwargs['arguments'] = "".join(argument_list)
@@ -142,6 +164,21 @@ class NotebookOp(ContainerOp):
         if self.pipeline_envs:
             for key,value in self.pipeline_envs.items():  # Convert dict entries to format kfp needs
                 self.container.add_env_variable(V1EnvVar(name=key, value=value))
+
+        # If crio volume size is found then assume kubeflow pipelines environment is using CRI-o as
+        # its container runtime
+        if self.crio_emptydir_volume_size:
+            self.add_volume(V1Volume(empty_dir=V1EmptyDirVolumeSource(
+                                     medium="",
+                                     size_limit=self.crio_emptydir_volume_size),
+                            name=self.crio_emptydir_volume_name))
+
+            self.container.add_volume_mount(V1VolumeMount(mount_path=self.container_work_dir,
+                                                          name=self.crio_emptydir_volume_name))
+
+            # Append to PYTHONPATH location of elyra dependencies in installed in Volume
+            self.container.add_env_variable(V1EnvVar(name='PYTHONPATH',
+                                                     value=self.crio_python_user_lib_path + ':$PYTHONPATH'))
 
     def _get_file_name_with_extension(self, name, extension):
         """ Simple function to construct a string filename

--- a/kfp_notebook/tests/test_notebook_op.py
+++ b/kfp_notebook/tests/test_notebook_op.py
@@ -122,6 +122,19 @@ def test_fail_with_empty_string_as_notebook():
     assert "You need to provide a notebook." == str(error_info.value)
 
 
+def test_user_volume_size():
+    notebook_op = NotebookOp(name="test",
+                             notebook="test_notebook.ipynb",
+                             cos_endpoint="http://testserver:32525",
+                             cos_bucket="test_bucket",
+                             cos_directory="test_directory",
+                             cos_dependencies_archive="test_archive.tgz",
+                             image="test/image:dev",
+                             emptydir_volume_size='20Gi')
+    assert notebook_op.emptydir_volume_size == '20Gi'
+    assert notebook_op.container_work_dir_root_path == '/mnt/'
+
+
 @pytest.mark.skip(reason="not sure if we should even test this")
 def test_default_bootstrap_url(notebook_op):
     assert notebook_op.bootstrap_script_url == 'https://raw.githubusercontent.com/elyra-ai/kfp-notebook/' \


### PR DESCRIPTION
- Added an empty dir volume for each notebook operation
- Redirects all writes in workspace to mounted volume including
installation of dependencies needed for Elyra.
- Appends Python library path to libraries installed on volume


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

