### PR TITLE
Add kernel matching logic based on available kernels

### DIFF
--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -270,7 +270,7 @@ class NotebookFileOp(FileOpBase):
             # load file (JSON) and pick out language, if match, use first found
             with open(os.path.join(file, 'kernel.json')) as f:
                 kspec = json.load(f)
-                if kspec.get('language') == nb_kernel_lang:
+                if kspec.get('language').lower() == nb_kernel_lang.lower():
                     matched_kernel = os.path.basename(file)
                     logger.info(f"Matched kernel by language ({nb_kernel_lang}), using kernel "
                                 f"'{matched_kernel}' instead of the missing kernel '{nb_kernel_name}'.")

--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -193,9 +193,11 @@ class NotebookFileOp(FileOpBase):
         try:
             OpUtil.log_operation_info(f"executing notebook using 'papermill {notebook} {notebook_output}'")
             t0 = time.time()
-            # Really hate to do this but have to invoke Papermill via library as workaround
+            # Include kernel selection in execution time
+            kernel_name = NotebookFileOp.find_best_kernel(notebook)
+
             import papermill
-            papermill.execute_notebook(notebook, notebook_output)
+            papermill.execute_notebook(notebook, notebook_output, kernel_name=kernel_name)
             duration = time.time() - t0
             OpUtil.log_operation_info("notebook execution completed", duration)
 
@@ -235,6 +237,49 @@ class NotebookFileOp(FileOpBase):
         duration = time.time() - t0
         OpUtil.log_operation_info(f"{notebook_file} converted to {html_file}", duration)
         return html_file
+
+    @staticmethod
+    def find_best_kernel(notebook_file: str) -> str:
+        """Determines the best kernel to use via the following algorithm:
+
+           1. Loads notebook and gets kernel_name and kernel_language from NB metadata.
+           2. Gets the list of configured kernels using KernelSpecManager.
+           3. If notebook kernel_name is in list, use that, else
+           4. If not found, load each configured kernel.json file and find a language match.
+           5. On first match, log info message regarding the switch and use that kernel.
+           6. If no language match is found, revert to notebook kernel and log warning message.
+        """
+        import json
+        import nbformat
+        from jupyter_client.kernelspec import KernelSpecManager
+
+        nb = nbformat.read(notebook_file, 4)
+
+        nb_kspec = nb.metadata.kernelspec
+        nb_kernel_name = nb_kspec.get('name')
+        nb_kernel_lang = nb_kspec.get('language')
+
+        kernel_specs = KernelSpecManager().find_kernel_specs()
+
+        # see if we have a direct match...
+        if nb_kernel_name in kernel_specs.keys():
+            return nb_kernel_name
+
+        # no match found for kernel, try matching language...
+        for name, file in kernel_specs.items():
+            # load file (JSON) and pick out language, if match, use first found
+            with open(os.path.join(file, 'kernel.json')) as f:
+                kspec = json.load(f)
+                if kspec.get('language') == nb_kernel_lang:
+                    matched_kernel = os.path.basename(file)
+                    logger.info(f"Matched kernel by language ({nb_kernel_lang}), using kernel "
+                                f"'{matched_kernel}' instead of the missing kernel '{nb_kernel_name}'.")
+                    return matched_kernel
+
+        # no match found for language, return notebook kernel and let execution fail
+        logger.warning(f"Reverting back to missing notebook kernel '{nb_kernel_name}' since no "
+                       f"language match ({nb_kernel_lang}) was found in current kernel specifications.")
+        return nb_kernel_name
 
 
 class PythonFileOp(FileOpBase):

--- a/etc/tests/test_bootstrapper.py
+++ b/etc/tests/test_bootstrapper.py
@@ -421,13 +421,14 @@ def test_find_best_kernel_lang(tmpdir, caplog):
     # "Copy" nb file to destination after updating the kernel name - forcing a language match
     nb = nbformat.read(source_nb_file, 4)
     nb.metadata.kernelspec['name'] = 'test-kernel'
+    nb.metadata.kernelspec['language'] = 'PYTHON'  # test case-insensitivity
     nbformat.write(nb, nb_file)
 
     with tmpdir.as_cwd():
         kernel_name = bootstrapper.NotebookFileOp.find_best_kernel(nb_file)
         assert kernel_name == 'python3'
         assert len(caplog.records) == 1
-        assert caplog.records[0].message.startswith("Matched kernel by language (python)")
+        assert caplog.records[0].message.startswith("Matched kernel by language (PYTHON)")
 
 
 def test_find_best_kernel_nomatch(tmpdir, caplog):


### PR DESCRIPTION
Because the environment in which notebook operations are run varies from that of the user's original desktop, it may be the case that the notebook-referenced kernel is not configured in the environment - which will cause its execution to fail.  With this change, the notebook-referenced kernel's existence is confirmed.  If not found, the first configured kernel matching the notebook kernel's language is used.  If no matches are found the notebook kernel is used - probably leading to a corresponding failure from papermill that the kernel cannot be found.

Resolves #58
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

