### PR TITLE
Remove dependency on SHA to validate generated html

### DIFF
--- a/etc/tests/test_bootstrapper.py
+++ b/etc/tests/test_bootstrapper.py
@@ -37,12 +37,7 @@ import bootstrapper
 # NOTE: Any changes to etc/tests/resources/test-notebookA.ipynb require an
 # update of etc/tests/resources/test-archive.tgz  using the command below:
 # tar -cvzf test-archive.tgz test-notebookA.ipynb
-#
-# There is also a need to update the following SHA256 hash used in
-# test_convert_notebook_to_html() below.
-#
 
-HTML_SHA256 = '4f717d3bbb41cb7b7d03814dee6639d3190e5b80f8a80b9af310b6109846d509'
 
 MINIO_HOST_PORT = os.getenv("MINIO_HOST_PORT", "127.0.0.1:9000")
 
@@ -329,7 +324,12 @@ def test_convert_notebook_to_html(tmpdir):
         bootstrapper.NotebookFileOp.convert_notebook_to_html(notebook_file, notebook_output_html_file)
 
         assert os.path.isfile(notebook_output_html_file)
-        assert hs.fileChecksum(notebook_output_html_file, "sha256") == HTML_SHA256
+        # Validate that an html file got generated from the notebook
+        with open(notebook_output_html_file, 'r') as html_file:
+            html_data = html_file.read()
+            assert html_data.startswith("<!DOCTYPE html>")
+            assert "&quot;TEST_ENV_VAR1&quot;" in html_data   # from os.getenv("TEST_ENV_VAR1")
+            assert html_data.endswith("</html>\n")
 
 
 def test_fail_convert_notebook_to_html(tmpdir):


### PR DESCRIPTION
The previous version relied on the SHA file checksum value to validate that the test notebook was properly converted to HTML.  However, a change to a transitive dependency changed the HTML output - breaking the test (and CI).

This change simply removes that dependency and confirms the generated HTML begins and ends with the appropriate HTML tags and ensures a small portion of code from the notebook file is properly converted to HTML.

Fixes #67
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

