### PR TITLE
Enable debug logging in bootstrapper

### DIFF
--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -425,7 +425,7 @@ def main():
     # Configure logger format, level
     logging.basicConfig(format='[%(levelname)1.1s %(asctime)s.%(msecs).03d] %(message)s',
                         datefmt='%H:%M:%S',
-                        level=logging.INFO)
+                        level=logging.DEBUG)
     # Setup packages and gather arguments
     input_params = OpUtil.parse_arguments(sys.argv[1:])
     OpUtil.log_operation_info("starting operation")


### PR DESCRIPTION
This change is related to [elyra issue #1055](https://github.com/elyra-ai/elyra/issues/1055) where the request is to allow the enablement of debug logging in kfp-notebook on a per node/pipeline basis.

Since any option will require that actual debug log statements be enabled and [Option 4](https://github.com/elyra-ai/elyra/issues/1055#issuecomment-726301885) in that issue is to simply have debug logging always enabled in kfp-notebook, I took a look at what debug statements are implemented but cannot be enabled, and found exactly one such statement: [`logger.debug("Parsing Arguments.....")`](https://github.com/elyra-ai/kfp-notebook/blob/master/etc/docker-scripts/bootstrapper.py#L380)

Given this, and coupled with the fact that much of the work added in #54 was for the sole purpose of troubleshooting, I think this is the way to proceed for the time being.  Should we find the need to add a multitude of additional debug statements and find that they should not always be enabled, then perhaps we can revisit the aforementioned elyra issue at that time.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

