### PR TITLE
Support Enterprise Gateway from KFP runtime

### DIFF
--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -195,7 +195,7 @@ class NotebookFileOp(FileOpBase):
             using_gateway = False
             if os.getenv("ELYRA_GATEWAY_ENABLED", "false").lower() == "true":
                 try:
-                    import elyra.pipeline.elyra_engine.ElyraEngine  # noqa
+                    from elyra.pipeline.elyra_engine import ElyraEngine  # noqa
                     using_gateway = True
                 except (ImportError, ModuleNotFoundError):
                     logger.warning("The papermill engine 'elyra.pipeline.elyra_engine.ElyraEngine' is not available.  "
@@ -452,8 +452,8 @@ def main():
 
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("Dumping environment...")
-        for k,v in os.environ.items():
-            logger.debug(f"{k}={v}")
+        for k in sorted(os.environ.keys()):
+            logger.debug(f"{k}={os.environ[k]}")
 
     # Create the appropriate instance, process dependencies and execute the operation
     file_op = FileOpBase.get_instance(**input_params)

--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -357,7 +357,10 @@ class OpUtil(object):
         to_install_list = []
 
         for package, ver in elyra_packages.items():
-            if package in current_packages:
+            if "git+" in ver:  # Check for git-based package
+                logger.info(f"Package {package} will be installed from {ver}...")
+                to_install_list.append(ver)
+            elif package in current_packages:
                 if "git+" in current_packages[package]:
                     logger.warning(f"WARNING: Source package {package} found already installed from "
                                    f"{current_packages[package]}. This may conflict with the required "
@@ -393,14 +396,15 @@ class OpUtil(object):
     def package_list_to_dict(cls, filename: str) -> dict:
         package_dict = {}
         with open(filename) as fh:
-            for line in fh:
-                if line[0] != '#':
+            for full_line in fh:
+                line = full_line.strip('\n').strip()
+                if line and line[0] != '#':  # Skip blank and commented lines
                     if " @ " in line:
-                        package_name, package_version = line.strip('\n').split(sep=" @ ")
+                        package_name, package_version = line.split(sep=" @ ")
                     elif "===" in line:
-                        package_name, package_version = line.strip('\n').split(sep="===")
+                        package_name, package_version = line.split(sep="===")
                     else:
-                        package_name, package_version = line.strip('\n').split(sep="==")
+                        package_name, package_version = line.split(sep="==")
 
                     package_dict[package_name] = package_version
 

--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -450,6 +450,11 @@ def main():
     t0 = time.time()
     OpUtil.package_install(user_volume_path=input_params.get('user-volume-path'))
 
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Dumping environment...")
+        for k,v in os.environ.items():
+            logger.debug(f"{k}={v}")
+
     # Create the appropriate instance, process dependencies and execute the operation
     file_op = FileOpBase.get_instance(**input_params)
 

--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -357,10 +357,7 @@ class OpUtil(object):
         to_install_list = []
 
         for package, ver in elyra_packages.items():
-            if "git+" in ver:  # Check for git-based package
-                logger.info(f"Package {package} will be installed from {ver}...")
-                to_install_list.append(ver)
-            elif package in current_packages:
+            if package in current_packages:
                 if "git+" in current_packages[package]:
                     logger.warning(f"WARNING: Source package {package} found already installed from "
                                    f"{current_packages[package]}. This may conflict with the required "
@@ -396,15 +393,14 @@ class OpUtil(object):
     def package_list_to_dict(cls, filename: str) -> dict:
         package_dict = {}
         with open(filename) as fh:
-            for full_line in fh:
-                line = full_line.strip('\n').strip()
-                if line and line[0] != '#':  # Skip blank and commented lines
+            for line in fh:
+                if line[0] != '#':
                     if " @ " in line:
-                        package_name, package_version = line.split(sep=" @ ")
+                        package_name, package_version = line.strip('\n').split(sep=" @ ")
                     elif "===" in line:
-                        package_name, package_version = line.split(sep="===")
+                        package_name, package_version = line.strip('\n').split(sep="===")
                     else:
-                        package_name, package_version = line.split(sep="==")
+                        package_name, package_version = line.strip('\n').split(sep="==")
 
                     package_dict[package_name] = package_version
 

--- a/etc/requirements-elyra.txt
+++ b/etc/requirements-elyra.txt
@@ -1,4 +1,7 @@
 # This is a comprehensive list of python dependencies that Elyra requires to execute Jupyter notebooks.
+# Any entries that are installed from github, should take the form, 'package_name @ git+https://github.com/org/repo@branch'
+#elyra-server==2.0.0
+elyra @ git+https://github.com/kevin-bates/elyra@support-eg-in-runtimes
 ipykernel==5.3.0
 ipython==7.15.0
 ipython-genutils==0.2.0

--- a/etc/requirements-elyra.txt
+++ b/etc/requirements-elyra.txt
@@ -1,7 +1,4 @@
 # This is a comprehensive list of python dependencies that Elyra requires to execute Jupyter notebooks.
-# Any entries that are installed from github, should take the form, 'package_name @ git+https://github.com/org/repo@branch'
-#elyra-server==2.0.0
-elyra @ git+https://github.com/kevin-bates/elyra@support-eg-in-runtimes
 ipykernel==5.3.0
 ipython==7.15.0
 ipython-genutils==0.2.0

--- a/etc/tests/test_bootstrapper.py
+++ b/etc/tests/test_bootstrapper.py
@@ -409,7 +409,7 @@ def test_find_best_kernel_nb(tmpdir):
     nbformat.write(nb, nb_file)
 
     with tmpdir.as_cwd():
-        kernel_name = bootstrapper.NotebookFileOp.find_best_kernel(nb_file)
+        kernel_name = bootstrapper.NotebookFileOp.find_best_kernel(nb_file, False)
         assert kernel_name == nb.metadata.kernelspec['name']
 
 
@@ -425,7 +425,7 @@ def test_find_best_kernel_lang(tmpdir, caplog):
     nbformat.write(nb, nb_file)
 
     with tmpdir.as_cwd():
-        kernel_name = bootstrapper.NotebookFileOp.find_best_kernel(nb_file)
+        kernel_name = bootstrapper.NotebookFileOp.find_best_kernel(nb_file, False)
         assert kernel_name == 'python3'
         assert len(caplog.records) == 1
         assert caplog.records[0].message.startswith("Matched kernel by language (PYTHON)")
@@ -442,7 +442,7 @@ def test_find_best_kernel_nomatch(tmpdir, caplog):
     nbformat.write(nb, nb_file)
 
     with tmpdir.as_cwd():
-        kernel_name = bootstrapper.NotebookFileOp.find_best_kernel(nb_file)
+        kernel_name = bootstrapper.NotebookFileOp.find_best_kernel(nb_file, False)
         assert kernel_name == 'test-kernel'
         assert len(caplog.records) == 1
         assert caplog.records[0].message.startswith("Reverting back to missing notebook kernel 'test-kernel'")

--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -167,15 +167,22 @@ class NotebookOp(ContainerOp):
                                  )
 
             if self.pipeline_inputs:
-                inputs_str = self._artifact_list_to_str(self.pipeline_inputs)
+                inputs_str = NotebookOp._artifact_list_to_str(self.pipeline_inputs)
                 argument_list.append('--inputs "{}" '.format(inputs_str))
 
             if self.pipeline_outputs:
-                outputs_str = self._artifact_list_to_str(self.pipeline_outputs)
+                outputs_str = NotebookOp._artifact_list_to_str(self.pipeline_outputs)
                 argument_list.append('--outputs "{}" '.format(outputs_str))
 
             if self.emptydir_volume_size:
                 argument_list.append('--user-volume-path "{}" '.format(self.python_user_lib_path))
+
+            if self.pipeline_envs:  # Collect env names to pass to kernel
+                names = []
+                for name in self.pipeline_envs.keys():
+                    names.append(name)
+                env_names = NotebookOp._artifact_list_to_str(names)  # convert to string with separator
+                argument_list.append('--env_names "{}" '.format(env_names))
 
             kwargs['command'] = ['sh', '-c']
             kwargs['arguments'] = "".join(argument_list)
@@ -203,7 +210,8 @@ class NotebookOp(ContainerOp):
             self.container.add_env_variable(V1EnvVar(name='PYTHONPATH',
                                                      value=self.python_user_lib_path))
 
-    def _artifact_list_to_str(self, pipeline_array):
+    @staticmethod
+    def _artifact_list_to_str(pipeline_array: list) -> str:
         trimmed_artifact_list = []
         for artifact_name in pipeline_array:
             if INOUT_SEPARATOR in artifact_name:  # if INOUT_SEPARATOR is in name, throw since this is our separator


### PR DESCRIPTION
This is the sibling PR to https://github.com/elyra-ai/elyra/pull/1103 and essentially leverages the Elyra papermill engine along with the `HTTPKernelManager` to issue notebook cell requests against an Enterprise Gateway server.  It determines the need to use the `HTTPKernelManager` based on the presence of the `ELYRA_GATEWAY_ENABLED` environment variable.  If present (and 'true') it confirms that the papermill engine is available and configures it to use the prescribed kernel manager.  The rest of the EG configuration items comes from the other `ELYRA_`-based envs that are conveyed to the container from the Elyra server.

Tasks for completion:
- [x] Configure use of `elyra_engine` and `HTTPKernelManager`
- [x] Gather appropriate envs to pass to kernel
- [ ] Look into supporting best-kernel lookup, although this may not be necessary when gateway is enabled
- [ ] Add elyra-server to `requirements-elyra.txt` - requires elyra release containing `elyra_engine` and `HTTPKernelManager`
- [ ] Since elyra-server would now be on the container, we should look into moving this into Elyra anyway
- [ ] How to manage cert and key files relative to SSL support?
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

