### PR TITLE
Add pod labels and annotation

### DIFF
--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -229,9 +229,12 @@ class NotebookOp(ContainerOp):
             self.container.set_gpu_limit(gpu=str(gpu_limit), vendor=gpu_vendor)
 
         # Attach metadata to the pod
+        # Node type (a static type for this op)
         self.add_pod_label('elyra-node-type', 'notebook-script')
+        # Pipeline node name
         self.add_pod_label('elyra-node-name', kwargs.get('name'))
-        self.add_pod_annotation('node-file-name', self.notebook)
+        # Pipeline node file
+        self.add_pod_annotation('elyra-node-file-name', self.notebook)
 
     def _artifact_list_to_str(self, pipeline_array):
         trimmed_artifact_list = []

--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -289,8 +289,8 @@ class NotebookOp(ContainerOp):
             value = 'a' + value[1:]
 
         # must end with [0-9a-zA-Z]
-        if value[len(value) - 1] not in valid_chars:
-            value = value[:len(value) - 1] + 'a'
+        if value[-1] not in valid_chars:
+            value = value[:-1] + 'a'
 
         valid_chars = valid_chars + '-_.'
 

--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -228,6 +228,11 @@ class NotebookOp(ContainerOp):
             gpu_vendor = self.pipeline_envs.get('GPU_VENDOR', 'nvidia')
             self.container.set_gpu_limit(gpu=str(gpu_limit), vendor=gpu_vendor)
 
+        # Attach metadata to the pod
+        self.add_pod_label('elyra-node-type', 'notebook-script')
+        self.add_pod_label('elyra-node-name', kwargs.get('name'))
+        self.add_pod_annotation('node-file-name', self.notebook)
+
     def _artifact_list_to_str(self, pipeline_array):
         trimmed_artifact_list = []
         for artifact_name in pipeline_array:

--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -292,7 +292,7 @@ class NotebookOp(ContainerOp):
         # that are in the "middle" of value. For example
         # a value of "abc%def" is converted to "abc_def".
         # The specified character must meet the label value
-        # constraints. 
+        # constraints.
         valid_middle_char = '_'
 
         # must begin with [0-9a-zA-Z]

--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -231,6 +231,10 @@ class NotebookOp(ContainerOp):
         # Attach metadata to the pod
         # Node type (a static type for this op)
         self.add_pod_label('elyra-node-type', 'notebook-script')
+        # Pipeline name
+        # Should we use kwargs.get('pipeline_name')?
+        self.add_pod_label('elyra-pipeline-name',
+                           self.cos_directory)
         # Pipeline node name
         self.add_pod_label('elyra-node-name', kwargs.get('name'))
         # Pipeline node file

--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -281,23 +281,35 @@ class NotebookOp(ContainerOp):
         if value is None or len(value) == 0:
             return ''   # nothing to do
 
-        value = value[:63]  # enforce max length 63
+        max_length = 63
+        replacement_char_first = 'a'
+        replacement_char_middle = '_'
+        replacement_char_last = 'a'
 
         # must begin with [0-9a-zA-Z]
         valid_chars = string.ascii_letters + string.digits
         if value[0] not in valid_chars:
-            value = 'a' + value[1:]
+            value = replacement_char_first + value
+
+        value = value[:max_length]  # enforce max length
 
         # must end with [0-9a-zA-Z]
         if value[-1] not in valid_chars:
-            value = value[:-1] + 'a'
+            if len(value) <= max_length - 1:
+                # append valid character if max length
+                # would not be exceeded
+                value = value + replacement_char_last
+            else:
+                # replace with valid character
+                value = value[:-1] + replacement_char_last
 
+        # middle chars must be [0-9a-zA-Z\-_.]
         valid_chars = valid_chars + '-_.'
 
         newstr = ''
         for c in range(len(value)):
             if value[c] not in valid_chars:
-                newstr = newstr + '_'
+                newstr = newstr + replacement_char_middle
             else:
                 newstr = newstr + value[c]
         value = newstr

--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -282,14 +282,23 @@ class NotebookOp(ContainerOp):
             return ''   # nothing to do
 
         max_length = 63
-        replacement_char_first = 'a'
-        replacement_char_middle = '_'
-        replacement_char_last = 'a'
+        # This char is added at the front and/or back
+        # of value, if the first and/or last character
+        # is invalid. For example a value of "-abc"
+        # is converted to "a-abc". The specified character
+        # must meet the label value constraints.
+        valid_char = 'a'
+        # This char is used to replace invalid characters
+        # that are in the "middle" of value. For example
+        # a value of "abc%def" is converted to "abc_def".
+        # The specified character must meet the label value
+        # constraints. 
+        valid_middle_char = '_'
 
         # must begin with [0-9a-zA-Z]
         valid_chars = string.ascii_letters + string.digits
         if value[0] not in valid_chars:
-            value = replacement_char_first + value
+            value = valid_char + value
 
         value = value[:max_length]  # enforce max length
 
@@ -298,10 +307,10 @@ class NotebookOp(ContainerOp):
             if len(value) <= max_length - 1:
                 # append valid character if max length
                 # would not be exceeded
-                value = value + replacement_char_last
+                value = value + valid_char
             else:
                 # replace with valid character
-                value = value[:-1] + replacement_char_last
+                value = value[:-1] + valid_char
 
         # middle chars must be [0-9a-zA-Z\-_.]
         valid_chars = valid_chars + '-_.'
@@ -309,7 +318,7 @@ class NotebookOp(ContainerOp):
         newstr = ''
         for c in range(len(value)):
             if value[c] not in valid_chars:
-                newstr = newstr + replacement_char_middle
+                newstr = newstr + valid_middle_char
             else:
                 newstr = newstr + value[c]
         value = newstr

--- a/kfp_notebook/tests/test_notebook_op.py
+++ b/kfp_notebook/tests/test_notebook_op.py
@@ -377,43 +377,126 @@ def test_construct_with_env_variables():
 
 
 def test_normalize_label_value():
+    valid_middle_chars = '-_.'
+
     # test min length
     assert NotebookOp._normalize_label_value(None) == ''
     assert NotebookOp._normalize_label_value('') == ''
-    # test max length
+    # test max length (63)
     assert NotebookOp._normalize_label_value('a' * 63) ==\
         'a' * 63
     assert NotebookOp._normalize_label_value('a' * 64) ==\
-        'a' * 63
+        'a' * 63  # truncated
     # test first and last char
     assert NotebookOp._normalize_label_value('1') == '1'
     assert NotebookOp._normalize_label_value('22') == '22'
     assert NotebookOp._normalize_label_value('3_3') == '3_3'
     assert NotebookOp._normalize_label_value('4u4') == '4u4'
+    assert NotebookOp._normalize_label_value('5$5') == '5_5'
 
-    # test invalid first char
+    # test first char
     for c in string.printable:
         if c in string.ascii_letters + string.digits:
+            # first char is valid
+            # no length violation
             assert NotebookOp._normalize_label_value(c) == c
-            assert NotebookOp._normalize_label_value(c + 'a') == c + 'a'
+            assert NotebookOp._normalize_label_value(c + 'B') == c + 'B'
+            # max length
+            assert NotebookOp._normalize_label_value(c + 'B' * 62) ==\
+                (c + 'B' * 62)
+            # max length exceeded
+            assert NotebookOp._normalize_label_value(c + 'B' * 63) ==\
+                (c + 'B' * 62)  # truncated
         else:
-            assert NotebookOp._normalize_label_value(c) == 'a'
-            assert NotebookOp._normalize_label_value(c + 'a') == 'aa'
+            # first char is invalid, e.g. '#a', and becomes the
+            # second char, which might require replacement
+            rv = c
+            if c not in valid_middle_chars:
+                rv = '_'
+            # no length violation
+            assert NotebookOp._normalize_label_value(c) == 'a' + rv + 'a'
+            assert NotebookOp._normalize_label_value(c + 'B') == 'a' + rv + 'B'
+            # max length
+            assert NotebookOp._normalize_label_value(c + 'B' * 62) ==\
+                ('a' + rv + 'B' * 61)  # truncated
+            # max length exceeded
+            assert NotebookOp._normalize_label_value(c + 'B' * 63) ==\
+                ('a' + rv + 'B' * 61)  # truncated
 
-    # test invalid last char
+    # test last char
     for c in string.printable:
         if c in string.ascii_letters + string.digits:
-            assert NotebookOp._normalize_label_value('a' + c) == 'a' + c
+            # no length violation
+            assert NotebookOp._normalize_label_value('b' + c) == 'b' + c
+            # max length
+            assert NotebookOp._normalize_label_value('b' * 62 + c) ==\
+                ('b' * 62 + c)
+            # max length exceeded
+            assert NotebookOp._normalize_label_value('b' * 63 + c) ==\
+                ('b' * 63)
         else:
-            assert NotebookOp._normalize_label_value('a' + c) == 'aa'
+            # last char is invalid, e.g. 'a#', and requires
+            # patching
+            rv = c
+            if c not in valid_middle_chars:
+                rv = '_'
+            # no length violation (char is appended)
+            assert NotebookOp._normalize_label_value('b' + c) == 'b' + rv + 'a'
+            # max length (char is replaced)
+            assert NotebookOp._normalize_label_value('b' * 62 + c) ==\
+                ('b' * 62 + 'a')
+            # max length exceeded (no action required)
+            assert NotebookOp._normalize_label_value('b' * 63 + c) ==\
+                ('b' * 63)
 
-    # test invalid char
+    # test first and last char
+    for c in string.printable:
+        if c in string.ascii_letters + string.digits:
+            # no length violation
+            assert NotebookOp._normalize_label_value(c + 'b' + c) ==\
+                c + 'b' + c  # nothing is modified
+            # max length
+            assert NotebookOp._normalize_label_value(c + 'b' * 61 + c) ==\
+                (c + 'b' * 61 + c)  # nothing is modified
+            # max length exceeded
+            assert NotebookOp._normalize_label_value(c + 'b' * 62 + c) ==\
+                c + 'b' * 62  # truncate only
+        else:
+            # first and last characters are invalid, e.g. '#a#'
+            rv = c
+            if c not in valid_middle_chars:
+                rv = '_'
+            # no length violation
+            assert NotebookOp._normalize_label_value(c + 'b' + c) ==\
+                'a' + rv + 'b' + rv + 'a'
+            # max length
+            assert NotebookOp._normalize_label_value(c + 'b' * 59 + c) ==\
+                ('a' + rv + 'b' * 59 + rv + 'a')
+            # max length exceeded after processing, scenario 1
+            # resolved by adding char before first, replace last
+            assert NotebookOp._normalize_label_value(c + 'b' * 60 + c) ==\
+                ('a' + rv + 'b' * 60 + 'a')
+            # max length exceeded after processing, scenario 2
+            # resolved by adding char before first, appending after last
+            assert NotebookOp._normalize_label_value(c + 'b' * 59 + c) ==\
+                ('a' + rv + 'b' * 59 + rv + 'a')
+            # max length exceeded before processing, scenario 1
+            # resolved by adding char before first, truncating last
+            assert NotebookOp._normalize_label_value(c + 'b' * 62 + c) ==\
+                ('a' + rv + 'b' * 61)
+            # max length exceeded before processing, scenario 2
+            # resolved by adding char before first, replacing last
+            assert NotebookOp._normalize_label_value(c + 'b' * 60 + c * 3) ==\
+                ('a' + rv + 'b' * 60 + 'a')
+
+    # test char in a position other than first and last
+    # if invalid, the char is replaced with '_'
     for c in string.printable:
         if c in string.ascii_letters + string.digits + '-_.':
-            assert NotebookOp._normalize_label_value('a' + c + 'z') ==\
-                'a' + c + 'z'
+            assert NotebookOp._normalize_label_value('A' + c + 'Z') ==\
+                'A' + c + 'Z'
         else:
-            assert NotebookOp._normalize_label_value('a' + c + 'z') == 'a_z'
+            assert NotebookOp._normalize_label_value('A' + c + 'Z') == 'A_Z'
 
     # encore
-    assert NotebookOp._normalize_label_value(r'¯\_(ツ)_/¯') == 'a_______a'
+    assert NotebookOp._normalize_label_value(r'¯\_(ツ)_/¯') == 'a_________a'

--- a/kfp_notebook/tests/test_notebook_op.py
+++ b/kfp_notebook/tests/test_notebook_op.py
@@ -13,13 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import pytest
 from kfp_notebook.pipeline import NotebookOp
+import pytest
+import string
 
 
 @pytest.fixture
 def notebook_op():
     return NotebookOp(name="test",
+                      pipeline_name="test-pipeline",
+                      experiment_name="experiment-name",
                       notebook="test_notebook.ipynb",
                       cos_endpoint="http://testserver:32525",
                       cos_bucket="test_bucket",
@@ -31,6 +34,8 @@ def notebook_op():
 def test_fail_without_cos_endpoint():
     with pytest.raises(TypeError):
         NotebookOp(name="test",
+                   pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
                    notebook="test_notebook.ipynb",
                    cos_bucket="test_bucket",
                    cos_directory="test_directory",
@@ -41,6 +46,8 @@ def test_fail_without_cos_endpoint():
 def test_fail_without_cos_bucket():
     with pytest.raises(TypeError):
         NotebookOp(name="test",
+                   pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
                    notebook="test_notebook.ipynb",
                    cos_endpoint="http://testserver:32525",
                    cos_directory="test_directory",
@@ -51,6 +58,8 @@ def test_fail_without_cos_bucket():
 def test_fail_without_cos_directory():
     with pytest.raises(TypeError):
         NotebookOp(name="test",
+                   pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
                    notebook="test_notebook.ipynb",
                    cos_endpoint="http://testserver:32525",
                    cos_bucket="test_bucket",
@@ -61,6 +70,8 @@ def test_fail_without_cos_directory():
 def test_fail_without_cos_dependencies_archive():
     with pytest.raises(TypeError):
         NotebookOp(name="test",
+                   pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
                    notebook="test_notebook.ipynb",
                    cos_endpoint="http://testserver:32525",
                    cos_bucket="test_bucket",
@@ -71,6 +82,8 @@ def test_fail_without_cos_dependencies_archive():
 def test_fail_without_runtime_image():
     with pytest.raises(ValueError) as error_info:
         NotebookOp(name="test",
+                   pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
                    notebook="test_notebook.ipynb",
                    cos_endpoint="http://testserver:32525",
                    cos_bucket="test_bucket",
@@ -82,6 +95,8 @@ def test_fail_without_runtime_image():
 def test_fail_without_notebook():
     with pytest.raises(TypeError):
         NotebookOp(name="test",
+                   pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
                    cos_endpoint="http://testserver:32525",
                    cos_bucket="test_bucket",
                    cos_directory="test_directory",
@@ -91,7 +106,9 @@ def test_fail_without_notebook():
 
 def test_fail_without_name():
     with pytest.raises(TypeError):
-        NotebookOp(notebook="test_notebook.ipynb",
+        NotebookOp(pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
+                   notebook="test_notebook.ipynb",
                    cos_endpoint="http://testserver:32525",
                    cos_bucket="test_bucket",
                    cos_directory="test_directory",
@@ -102,6 +119,8 @@ def test_fail_without_name():
 def test_fail_with_empty_string_as_name():
     with pytest.raises(ValueError):
         NotebookOp(name="",
+                   pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
                    notebook="test_notebook.ipynb",
                    cos_endpoint="http://testserver:32525",
                    cos_bucket="test_bucket",
@@ -113,6 +132,8 @@ def test_fail_with_empty_string_as_name():
 def test_fail_with_empty_string_as_notebook():
     with pytest.raises(ValueError) as error_info:
         NotebookOp(name="test",
+                   pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
                    notebook="",
                    cos_endpoint="http://testserver:32525",
                    cos_bucket="test_bucket",
@@ -122,8 +143,34 @@ def test_fail_with_empty_string_as_notebook():
     assert "You need to provide a notebook." == str(error_info.value)
 
 
+def test_fail_without_pipeline_name():
+    with pytest.raises(TypeError):
+        NotebookOp(name="test",
+                   experiment_name="experiment-name",
+                   notebook="test_notebook.ipynb",
+                   cos_endpoint="http://testserver:32525",
+                   cos_bucket="test_bucket",
+                   cos_directory="test_directory",
+                   cos_dependencies_archive="test_archive.tgz",
+                   image="test/image:dev")
+
+
+def test_fail_without_experiment_name():
+    with pytest.raises(TypeError):
+        NotebookOp(name="test",
+                   pipeline_name="test-pipeline",
+                   notebook="test_notebook.ipynb",
+                   cos_endpoint="http://testserver:32525",
+                   cos_bucket="test_bucket",
+                   cos_directory="test_directory",
+                   cos_dependencies_archive="test_archive.tgz",
+                   image="test/image:dev")
+
+
 def test_properly_set_notebook_name_when_in_subdirectory():
     notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
                              notebook="foo/test_notebook.ipynb",
                              cos_endpoint="http://testserver:32525",
                              cos_bucket="test_bucket",
@@ -135,6 +182,8 @@ def test_properly_set_notebook_name_when_in_subdirectory():
 
 def test_properly_set_python_script_name_when_in_subdirectory():
     notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
                              notebook="foo/test.py",
                              cos_endpoint="http://testserver:32525",
                              cos_bucket="test_bucket",
@@ -146,6 +195,8 @@ def test_properly_set_python_script_name_when_in_subdirectory():
 
 def test_user_crio_volume_creation():
     notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
                              notebook="test_notebook.ipynb",
                              cos_endpoint="http://testserver:32525",
                              cos_bucket="test_bucket",
@@ -167,6 +218,8 @@ def test_default_bootstrap_url(notebook_op):
 
 def test_override_bootstrap_url():
     notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
                              bootstrap_script_url="https://test.server.com/bootscript.py",
                              notebook="test_notebook.ipynb",
                              cos_endpoint="http://testserver:32525",
@@ -185,6 +238,8 @@ def test_default_requirements_url(notebook_op):
 
 def test_override_requirements_url():
     notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
                              requirements_url="https://test.server.com/requirements.py",
                              notebook="test_notebook.ipynb",
                              cos_endpoint="http://testserver:32525",
@@ -197,6 +252,8 @@ def test_override_requirements_url():
 
 def test_construct_with_both_pipeline_inputs_and_outputs():
     notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
                              notebook="test_notebook.ipynb",
                              cos_endpoint="http://testserver:32525",
                              cos_bucket="test_bucket",
@@ -214,6 +271,8 @@ def test_construct_with_both_pipeline_inputs_and_outputs():
 
 def test_construct_wiildcard_outputs():
     notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
                              notebook="test_notebook.ipynb",
                              cos_endpoint="http://testserver:32525",
                              cos_bucket="test_bucket",
@@ -231,6 +290,8 @@ def test_construct_wiildcard_outputs():
 
 def test_construct_with_only_pipeline_inputs():
     notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
                              notebook="test_notebook.ipynb",
                              cos_endpoint="http://testserver:32525",
                              cos_bucket="test_bucket",
@@ -246,6 +307,8 @@ def test_construct_with_only_pipeline_inputs():
 def test_construct_with_bad_pipeline_inputs():
     with pytest.raises(ValueError) as error_info:
         NotebookOp(name="test",
+                   pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
                    notebook="test_notebook.ipynb",
                    cos_endpoint="http://testserver:32525",
                    cos_bucket="test_bucket",
@@ -259,6 +322,8 @@ def test_construct_with_bad_pipeline_inputs():
 
 def test_construct_with_only_pipeline_outputs():
     notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
                              notebook="test_notebook.ipynb",
                              cos_endpoint="http://testserver:32525",
                              cos_bucket="test_bucket",
@@ -274,6 +339,8 @@ def test_construct_with_only_pipeline_outputs():
 def test_construct_with_bad_pipeline_outputs():
     with pytest.raises(ValueError) as error_info:
         NotebookOp(name="test",
+                   pipeline_name="test-pipeline",
+                   experiment_name="experiment-name",
                    notebook="test_notebook.ipynb",
                    cos_endpoint="http://testserver:32525",
                    cos_bucket="test_bucket",
@@ -286,6 +353,8 @@ def test_construct_with_bad_pipeline_outputs():
 
 def test_construct_with_env_variables():
     notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
                              notebook="test_notebook.ipynb",
                              cos_endpoint="http://testserver:32525",
                              cos_bucket="test_bucket",
@@ -305,3 +374,46 @@ def test_construct_with_env_variables():
     # Verify confirmation values have been drained.
     assert len(confirmation_names) == 0
     assert len(confirmation_values) == 0
+
+
+def test_normalize_label_value():
+    # test min length
+    assert NotebookOp._normalize_label_value(None) == ''
+    assert NotebookOp._normalize_label_value('') == ''
+    # test max length
+    assert NotebookOp._normalize_label_value('a' * 63) ==\
+        'a' * 63
+    assert NotebookOp._normalize_label_value('a' * 64) ==\
+        'a' * 63
+    # test first and last char
+    assert NotebookOp._normalize_label_value('1') == '1'
+    assert NotebookOp._normalize_label_value('22') == '22'
+    assert NotebookOp._normalize_label_value('3_3') == '3_3'
+    assert NotebookOp._normalize_label_value('4u4') == '4u4'
+
+    # test invalid first char
+    for c in string.printable:
+        if c in string.ascii_letters + string.digits:
+            assert NotebookOp._normalize_label_value(c) == c
+            assert NotebookOp._normalize_label_value(c + 'a') == c + 'a'
+        else:
+            assert NotebookOp._normalize_label_value(c) == 'a'
+            assert NotebookOp._normalize_label_value(c + 'a') == 'aa'
+
+    # test invalid last char
+    for c in string.printable:
+        if c in string.ascii_letters + string.digits:
+            assert NotebookOp._normalize_label_value('a' + c) == 'a' + c
+        else:
+            assert NotebookOp._normalize_label_value('a' + c) == 'aa'
+
+    # test invalid char
+    for c in string.printable:
+        if c in string.ascii_letters + string.digits + '-_.':
+            assert NotebookOp._normalize_label_value('a' + c + 'z') ==\
+                'a' + c + 'z'
+        else:
+            assert NotebookOp._normalize_label_value('a' + c + 'z') == 'a_z'
+
+    # encore
+    assert NotebookOp._normalize_label_value(r'¯\_(ツ)_/¯') == 'a_______a'


### PR DESCRIPTION
This PR
 - changes the `NotebookOp` constructor signature, adding
   - `pipeline_name` (required, no default)
   - `pipeline_version` (optional, default: `<empty string>`)
   - `experiment_name`  (required, no default) 
 - adds pod label(s)
   -  `elyra/node-type` => always `notebook-script` until Pipelines 2.0
   - `elyra/pipeline-name`
   - `elyra/pipeline-version`
   - `elyra/experiment-name`
   - `elyra/node-name`
 - adds pod annotation(s)
   - `elyra/node-file-name`
  - updates existing tests to accomodate constructor signature change
  - adds static class method `_normalize_label_value` 
 - adds tests for above method
 - partially solves https://github.com/elyra-ai/elyra/issues/1277 (another PR is required to handle pipeline export to Python DSL)
 - temporarily breaks elyra-ai/elyra due to `NotebookOp` signature change
 
With this enhancement administrators can
- identify which pods are associated with Elyra pipelines (in general)
- identify the Python script | notebook that's associated with the pod

### Labels metadata:
- `elyra-node-type`: static string identifying the node type as `notebook-script`, which covers file-based Elyra container ops for notebooks and Python scripts
- `elyra-pipeline-name`: the pipeline's experiment name, e.g. `my-labeled-pipeline3-0208165033` which is not the same as the pipeline name
- `elyra-node-name`: the pipeline node name (see also https://github.com/elyra-ai/elyra/issues/971)

### Annotations metadata:
- `elyra-node-file-name`: the notebook or Python script name, e.g. `notebook1.ipynb`

### How to test:

- Build and run
  ```
  $ make clean install 
  $ export ELYRA_GITHUB_BRANCH=i1277
  $ export ELYRA_GITHUB_ORG=ptitzler
  $ jupyter lab
  ```
#### Testing pipeline execution

- Create a pipeline and add any number of nodes
- Run the pipeline on KFP
- Log on to the KFP cluster 
- Run the following commands, replacing `[NAMESPACE]` with your namespace name
   ```
   # should return one entry for every node in every pipeline
   $ kubectl get pods -l=elyra-node-type --namespace=[NAMESPACE]
   # # should return one entry for every node in experiment EXPERIMENT_NAME
   $ kubectl get pods --selector=elyra-pipeline-name=[EXPERIMENT_NAME] 

   # should return one entry for every file-based node in the pipeline (results will differ once
   # Elyra supports Kubeflow components, which would be of a different type
   $ kubectl get pods --selector=elyra-node-type=notebook-script --namespace=[NAMESPACE]

   # for each [POD_NAME]  entry returned by the queries above run
   $ kubectl describe pods [POD_NAME] --namespace=[NAMESPACE]
   ```
 
#### Testing pipeline export to YAML
- Create a pipeline and add any number of nodes
- Export the pipeline to YAML
- Inspect the generated YAML file and verify that the following entries are present for each node (`[FILENAME]` and `[NODE_NAME]` are actual values from your pipeline)
   ```
   metadata:
        annotations: {elyra-node-file-name: [FILENAME]}
        labels: {elyra-node-type: notebook-script, elyra-node-name: [NODE_NAME], elyra-pipeline-name: [EXPERIMENT_NAME]}
   ```


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

