### PR TITLE
Update test target behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-dependencies:
 	@pip install -q -r test-requirements.txt
 
 test: test-dependencies test-start-minio ## run tests quickly with the default Python
-	coverage run -m pytest; r=$$?; $(MAKE) test-stop-minio; exit $$r
+	coverage run -m pytest -v; r=$$?; $(MAKE) test-stop-minio; exit $$r
 
 test-start-minio: ## start test_minio container (dev testing)
 	docker run --name test_minio -d -p 9000:9000 minio/minio server /data

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-dependencies:
 	@pip install -q -r test-requirements.txt
 
 test: test-dependencies test-start-minio ## run tests quickly with the default Python
-	coverage run -m pytest -v || $$(make test-stop-minio)
+	- coverage run -m pytest -v
 	@make test-stop-minio
 
 test-start-minio: ## start test_minio container (dev testing)

--- a/Makefile
+++ b/Makefile
@@ -63,14 +63,13 @@ test-dependencies:
 	@pip install -q -r test-requirements.txt
 
 test: test-dependencies test-start-minio ## run tests quickly with the default Python
-	- coverage run -m pytest -v
-	@make test-stop-minio
+	coverage run -m pytest; r=$$?; $(MAKE) test-stop-minio; exit $$r
 
 test-start-minio: ## start test_minio container (dev testing)
 	docker run --name test_minio -d -p 9000:9000 minio/minio server /data
 
 test-stop-minio: ## stop test_minio container (dev testing)
-	@docker rm -f test_minio
+	@-docker rm -f test_minio >/dev/null 2>&1
 
 test-all: ## run tests on every Python version with tox
 	tox


### PR DESCRIPTION
This PR changes the behavior of `make test`. 

Scenario: `make test` fails due to an issue with a test case

Old behavior:

`@make test-stop-minio` fails because the command was already executed

```
/bin/sh: test_minio: command not found
make: *** [test] Error 127
``` 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

