### PR TITLE
Add support for pipeline source annotation

### DIFF
--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -61,6 +61,7 @@ class NotebookOp(ContainerOp):
                  cos_directory: str,
                  cos_dependencies_archive: str,
                  pipeline_version: Optional[str] = '',
+                 pipeline_source: Optional[str] = None,
                  pipeline_outputs: Optional[List[str]] = None,
                  pipeline_inputs: Optional[List[str]] = None,
                  pipeline_envs: Optional[Dict[str, str]] = None,
@@ -80,6 +81,8 @@ class NotebookOp(ContainerOp):
           cos_bucket: bucket to retrieve archive from
           cos_directory: name of the directory in the object storage bucket to pull
           cos_dependencies_archive: archive file name to get from object storage bucket e.g archive1.tar.gz
+          pipeline_version: optional version identifier
+          pipeline_source: pipeline source
           pipeline_outputs: comma delimited list of files produced by the notebook
           pipeline_inputs: comma delimited list of files to be consumed/are required by the notebook
           pipeline_envs: dictionary of environmental variables to set in the container prior to execution
@@ -96,6 +99,7 @@ class NotebookOp(ContainerOp):
 
         self.pipeline_name = pipeline_name
         self.pipeline_version = pipeline_version
+        self.pipeline_source = pipeline_source
         self.experiment_name = experiment_name
         self.notebook = notebook
         self.notebook_name = os.path.basename(notebook)
@@ -257,6 +261,13 @@ class NotebookOp(ContainerOp):
         # Pipeline node file
         self.add_pod_annotation('elyra/node-file-name',
                                 self.notebook)
+
+        # Identify the pipeline source, which can be a
+        # pipeline file (mypipeline.pipeline), a Python
+        # script or notebook that was submitted
+        if self.pipeline_source is not None:
+            self.add_pod_annotation('elyra/pipeline-source',
+                                    self.pipeline_source)
 
     def _artifact_list_to_str(self, pipeline_array):
         trimmed_artifact_list = []


### PR DESCRIPTION
The pipeline source annotation identifies the source that created a pipeline. Example sources are .pipeline files, or a Python script or notebook that is run ad-hoc.

A corresponding update will be delivered for elyra-ai/elyra

Refer to https://github.com/elyra-ai/elyra/issues/1299 for details. 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

