### PR TITLE
Set PYTHONPATH at runtime to avoid override of existing env

### DIFF
--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -173,9 +173,11 @@ class NotebookOp(ContainerOp):
             if self.emptydir_volume_size:
                 argument_list.append('mkdir {container_python_dir} && cd {container_python_dir} && '
                                      'curl -H "Cache-Control: no-cache" -L {python_pip_config_url} '
-                                     '--output pip.conf && cd .. &&'
+                                     '--output pip.conf && cd .. && '
+                                     'export PYTHONPATH={python_user_lib_path}/$PYTHONPATH &&'
                                      .format(python_pip_config_url=self.python_pip_config_url,
-                                             container_python_dir=self.container_python_dir_name)
+                                             container_python_dir=self.container_python_dir_name,
+                                             python_user_lib_path=self.python_user_lib_path)
                                      )
 
             argument_list.append('python3 -m pip install {python_user_lib_path_target} packaging && '
@@ -226,10 +228,6 @@ class NotebookOp(ContainerOp):
 
             self.container.add_volume_mount(V1VolumeMount(mount_path=self.container_work_dir_root_path,
                                                           name=self.emptydir_volume_name))
-
-            # Append to PYTHONPATH location of elyra dependencies in installed in Volume
-            self.container.add_env_variable(V1EnvVar(name='PYTHONPATH',
-                                                     value=self.python_user_lib_path))
 
         if self.cpu_request:
             self.container.set_cpu_request(cpu=str(cpu_request))

--- a/kfp_notebook/tests/test_notebook_op.py
+++ b/kfp_notebook/tests/test_notebook_op.py
@@ -207,7 +207,6 @@ def test_user_crio_volume_creation():
     assert notebook_op.emptydir_volume_size == '20Gi'
     assert notebook_op.container_work_dir_root_path == '/opt/app-root/src/'
     assert notebook_op.container.volume_mounts.__len__() == 1
-    assert notebook_op.container.env.__len__() == 1
 
 
 @pytest.mark.skip(reason="not sure if we should even test this")


### PR DESCRIPTION
Avoid setting the PYTHONPATH via the container_op helper functions
which override the existing PYTHONPATH and instead prepend the
existing path at runtime

Fixes #90



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

