### PR TITLE
Update cos client to use secure connection when specified in URL

### DIFF
--- a/etc/docker-scripts/bootstrapper.py
+++ b/etc/docker-scripts/bootstrapper.py
@@ -71,11 +71,14 @@ class FileOpBase(ABC):
         self.input_params = kwargs or []
         self.cos_endpoint = urlparse(self.input_params.get('cos-endpoint'))
         self.cos_bucket = self.input_params.get('cos-bucket')
-        # TODO(check hardcoded false)
+
+        # Infer secure from the endpoint's scheme.
+        self.secure = self.cos_endpoint.scheme == 'https'
+
         self.cos_client = minio.Minio(self.cos_endpoint.netloc,
                                       access_key=os.getenv('AWS_ACCESS_KEY_ID'),
                                       secret_key=os.getenv('AWS_SECRET_ACCESS_KEY'),
-                                      secure=False)
+                                      secure=self.secure)
 
     @abstractmethod
     def execute(self) -> None:


### PR DESCRIPTION
Use secure connection (https) in minio client whenever secure flag
(https) is found in cos endpoint URL instead of always using an
insecure connection to S3 object storage.

Fixes #94

![image](https://user-images.githubusercontent.com/13340013/115910665-f5d22c80-a421-11eb-8927-c897b53a0b0a.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

