### PR TITLE
Add support for ELYRA_RUN_NAME environment variable for KFP execution

### DIFF
--- a/kfp_notebook/pipeline/_notebook_op.py
+++ b/kfp_notebook/pipeline/_notebook_op.py
@@ -19,7 +19,6 @@ import os
 import string
 
 from kfp.dsl import ContainerOp
-from kfp.dsl import RUN_ID_PLACEHOLDER
 from kfp_notebook import __version__
 from kubernetes.client.models import V1EmptyDirVolumeSource, V1EnvVar, V1Volume, V1VolumeMount
 from typing import Dict, List, Optional
@@ -72,6 +71,7 @@ class NotebookOp(ContainerOp):
                  cpu_request: Optional[str] = None,
                  mem_request: Optional[str] = None,
                  gpu_limit: Optional[str] = None,
+                 workflow_engine: Optional[str] = 'argo',
                  **kwargs):
         """Create a new instance of ContainerOp.
         Args:
@@ -93,6 +93,7 @@ class NotebookOp(ContainerOp):
           cpu_request: number of CPUs requested for the operation
           mem_request: memory requested for the operation (in Gi)
           gpu_limit: maximum number of GPUs allowed for the operation
+          workflow_engine: Kubeflow workflow engine, defaults to 'argo'
           kwargs: additional key value pairs to pass e.g. name, image, sidecars & is_exit_handler.
                   See Kubeflow pipelines ContainerOp definition for more parameters or how to use
                   https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp
@@ -242,14 +243,14 @@ class NotebookOp(ContainerOp):
             gpu_vendor = self.pipeline_envs.get('GPU_VENDOR', 'nvidia')
             self.container.set_gpu_limit(gpu=str(gpu_limit), vendor=gpu_vendor)
 
-        # Generate unique ELYRA_RUN_ID value and expose it as an environment
+        # Generate unique ELYRA_RUN_NAME value and expose it as an environment
         # variable in the container
-        if self.pipeline_version:
-            elyra_run_id_val = f'{self.pipeline_version}-{RUN_ID_PLACEHOLDER}'
+        if workflow_engine and workflow_engine.lower() == 'argo':
+            run_name_placeholder = '{{workflow.annotations.pipelines.kubeflow.org/run_name}}'
         else:
-            elyra_run_id_val = f'{self.pipeline_name}-{RUN_ID_PLACEHOLDER}'
-        self.container.add_env_variable(V1EnvVar(name='ELYRA_RUN_ID',
-                                                 value=elyra_run_id_val))
+            run_name_placeholder = '$(context.pipelineRun.name)'
+        self.container.add_env_variable(V1EnvVar(name='ELYRA_RUN_NAME',
+                                                 value=run_name_placeholder))
 
         # Attach metadata to the pod
         # Node type (a static type for this op)

--- a/kfp_notebook/tests/test_notebook_op.py
+++ b/kfp_notebook/tests/test_notebook_op.py
@@ -207,7 +207,7 @@ def test_user_crio_volume_creation():
     assert notebook_op.emptydir_volume_size == '20Gi'
     assert notebook_op.container_work_dir_root_path == '/opt/app-root/src/'
     assert notebook_op.container.volume_mounts.__len__() == 1
-    # Environment variables: PYTHONPATH, ELYRA_RUN_ID
+    # Environment variables: PYTHONPATH, ELYRA_RUN_NAME
     assert notebook_op.container.env.__len__() == 2, notebook_op.container.env
 
 
@@ -352,7 +352,7 @@ def test_construct_with_bad_pipeline_outputs():
     assert "Illegal character (;) found in filename 'test;output2.txt'." == str(error_info.value)
 
 
-def test_construct_with_env_variables():
+def test_construct_with_env_variables_argo():
     notebook_op = NotebookOp(name="test",
                              pipeline_name="test-pipeline",
                              experiment_name="experiment-name",
@@ -365,17 +365,70 @@ def test_construct_with_env_variables():
                              image="test/image:dev")
 
     confirmation_names = ["ENV_VAR_ONE", "ENV_VAR_TWO", "ENV_VAR_THREE",
-                          "ELYRA_RUN_ID"]
-    confirmation_values = ["1", "2", "3"]
+                          "ELYRA_RUN_NAME"]
+    confirmation_values = ["1", "2", "3",
+                           "{{workflow.annotations.pipelines.kubeflow.org/run_name}}"]
     for env_val in notebook_op.container.env:
         assert env_val.name in confirmation_names
-        if env_val.name == 'ELYRA_RUN_ID':
-            assert env_val.value.startswith('test-pipeline')
-            confirmation_names.remove(env_val.name)
-        else:
-            assert env_val.value in confirmation_values
-            confirmation_names.remove(env_val.name)
-            confirmation_values.remove(env_val.value)
+        assert env_val.value in confirmation_values
+        confirmation_names.remove(env_val.name)
+        confirmation_values.remove(env_val.value)
+
+    # Verify confirmation values have been drained.
+    assert len(confirmation_names) == 0
+    assert len(confirmation_values) == 0
+
+    # same as before but explicitly specify the workflow engine type
+    # as Argo
+    notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
+                             notebook="test_notebook.ipynb",
+                             cos_endpoint="http://testserver:32525",
+                             cos_bucket="test_bucket",
+                             cos_directory="test_directory",
+                             cos_dependencies_archive="test_archive.tgz",
+                             pipeline_envs={"ENV_VAR_ONE": "1", "ENV_VAR_TWO": "2", "ENV_VAR_THREE": "3"},
+                             image="test/image:dev",
+                             workflow_engine="Argo")
+
+    confirmation_names = ["ENV_VAR_ONE", "ENV_VAR_TWO", "ENV_VAR_THREE",
+                          "ELYRA_RUN_NAME"]
+    confirmation_values = ["1", "2", "3",
+                           "{{workflow.annotations.pipelines.kubeflow.org/run_name}}"]
+    for env_val in notebook_op.container.env:
+        assert env_val.name in confirmation_names
+        assert env_val.value in confirmation_values
+        confirmation_names.remove(env_val.name)
+        confirmation_values.remove(env_val.value)
+
+    # Verify confirmation values have been drained.
+    assert len(confirmation_names) == 0
+    assert len(confirmation_values) == 0
+
+
+def test_construct_with_env_variables_tekton():
+    notebook_op = NotebookOp(name="test",
+                             pipeline_name="test-pipeline",
+                             experiment_name="experiment-name",
+                             notebook="test_notebook.ipynb",
+                             cos_endpoint="http://testserver:32525",
+                             cos_bucket="test_bucket",
+                             cos_directory="test_directory",
+                             cos_dependencies_archive="test_archive.tgz",
+                             pipeline_envs={"ENV_VAR_ONE": "1", "ENV_VAR_TWO": "2", "ENV_VAR_THREE": "3"},
+                             image="test/image:dev",
+                             workflow_engine="Tekton")
+
+    confirmation_names = ["ENV_VAR_ONE", "ENV_VAR_TWO", "ENV_VAR_THREE",
+                          "ELYRA_RUN_NAME"]
+    confirmation_values = ["1", "2", "3",
+                           "$(context.pipelineRun.name)"]
+    for env_val in notebook_op.container.env:
+        assert env_val.name in confirmation_names
+        assert env_val.value in confirmation_values
+        confirmation_names.remove(env_val.name)
+        confirmation_values.remove(env_val.value)
 
     # Verify confirmation values have been drained.
     assert len(confirmation_names) == 0

--- a/kfp_notebook/tests/test_notebook_op.py
+++ b/kfp_notebook/tests/test_notebook_op.py
@@ -422,13 +422,16 @@ def test_construct_with_env_variables_tekton():
 
     confirmation_names = ["ENV_VAR_ONE", "ENV_VAR_TWO", "ENV_VAR_THREE",
                           "ELYRA_RUN_NAME"]
-    confirmation_values = ["1", "2", "3",
-                           "$(context.pipelineRun.name)"]
+    confirmation_values = ["1", "2", "3"]
+    field_path = "metadata.annotations['pipelines.kubeflow.org/run_name']"
     for env_val in notebook_op.container.env:
         assert env_val.name in confirmation_names
-        assert env_val.value in confirmation_values
         confirmation_names.remove(env_val.name)
-        confirmation_values.remove(env_val.value)
+        if env_val.name == 'ELYRA_RUN_NAME':
+            assert env_val.value_from.field_ref.field_path == field_path, env_val.value_from.field_ref
+        else:
+            assert env_val.value in confirmation_values
+            confirmation_values.remove(env_val.value)
 
     # Verify confirmation values have been drained.
     assert len(confirmation_names) == 0

--- a/kfp_notebook/tests/test_notebook_op.py
+++ b/kfp_notebook/tests/test_notebook_op.py
@@ -207,7 +207,8 @@ def test_user_crio_volume_creation():
     assert notebook_op.emptydir_volume_size == '20Gi'
     assert notebook_op.container_work_dir_root_path == '/opt/app-root/src/'
     assert notebook_op.container.volume_mounts.__len__() == 1
-    assert notebook_op.container.env.__len__() == 1, notebook_op.container.env
+    # Environment variables: PYTHONPATH, ELYRA_RUN_ID
+    assert notebook_op.container.env.__len__() == 2, notebook_op.container.env
 
 
 @pytest.mark.skip(reason="not sure if we should even test this")


### PR DESCRIPTION
This PR complements https://github.com/elyra-ai/elyra/pull/1732 by introducing a new protected environment variable `ELYRA_RUN_NAME`, which is made available to notebooks | scripts during pipeline execution. The value is a unique string that changes for every pipeline run. For example
- run 1: `ELYRA_RUN_NAME`=`some_value`
- run 2: `ELYRA_RUN_NAME`=`some_other_value`

Notes:
- The actual value is the same for each node during pipeline execution.
- The actual value starts with the pipeline version (or pipeline name, if no version is defined ), e.g. `my-pipeline-` followed by a sequence of characters that assure uniqueness.
- The trailing character sequence is the run name, which was either user-provided or generated.
- The actual value is not persisted by Elyra.
- If the user manually overrides the variable value in the node properties (e.g. sets `ELYRA_RUN_NAME` to `bogusid`), the change is ignored, as it should be for all protected/system Elyra environment variables.

### How was this pull request tested?

- [Download/extract the test case archive](https://github.com/elyra-ai/kfp-notebook/files/6673600/1702_testcase.tar.gz)

 into a JL workspace
- Open `1702_test.pipeline` using the VPE (note that the comments indicate which nodes attempt to override the environment variable value
![image](https://user-images.githubusercontent.com/13068832/122482429-652d4e00-cf85-11eb-8ef9-fdcc4f903721.png)

- Run the pipeline on KF for the first time. The output should indicate that the environment variable is set to `1702_test-<timestamp>`. The first qualifier should be the pipeline name.

   ![image](https://user-images.githubusercontent.com/13068832/122482909-5004ef00-cf86-11eb-9d87-522b07fcf8e1.png)


- Run the pipeline again (without making any changes) on KF by cloning the run
   ![image](https://user-images.githubusercontent.com/13068832/122483100-aeca6880-cf86-11eb-9203-b3fb95386cfe.png)


-  The output should now indicate that the environment variable is set to the cloned run name (see above)
   ![image](https://user-images.githubusercontent.com/13068832/122483388-4cbe3300-cf87-11eb-926e-a6232bb6af34.png)

- Export the pipeline as YAML, upload file to KF and run manually: the first qualifier in `ELYRA_RUN_NAME` _is always the pipeline name and never the pipeline version_. The reason is that until the user manually uploads the YAML file to KF it is not known what the pipeline version is. Therefore Elyra does not have access to pipeline version information.
- Export the pipeline as Python DSL and run generated code manually: due to a [limitation of the export feature](https://github.com/elyra-ai/elyra/issues/1735) the first qualifier in `ELYRA_RUN_NAME` _is always the pipeline name and never the pipeline version_. 


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

